### PR TITLE
Fix linting config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "scripts": {
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint --fix",
-    "lint:all": "eslint packages/*/src/**/*.{ts,tsx} --fix",
+    "lint:all": "lerna run lint",
     "clean": "yarn run clean:artifacts && yarn run clean:packages && yarn run clean:root",
     "clean:artifacts": "lerna run clean --parallel",
     "clean:packages": "lerna clean --yes",

--- a/packages/api/.eslintrc
+++ b/packages/api/.eslintrc
@@ -3,5 +3,21 @@
     "no-useless-constructor": "off",
     "no-empty-function": ["error", { "allow": ["constructors"] }],
     "class-methods-use-this": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "test/*"
+      ],
+      "rules": {
+        "fp/no-mutation": "off",
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -11,4 +11,4 @@ import { ReefsModule } from './reefs/reefs.module';
   ],
   controllers: [AppController],
 })
-export class AppModule { }
+export class AppModule {}

--- a/packages/api/src/utils/temperature.test.ts
+++ b/packages/api/src/utils/temperature.test.ts
@@ -2,7 +2,7 @@ import { calculateDegreeHeatingDays } from './temperature';
 
 // Mock functions
 function getSeaSurfaceTemperatures(reefID: number) {
-  return Array.from(Array(reefID), (_, index) => index)
+  return Array.from(Array(reefID), (_, index) => index);
 }
 
 function getMaximumMonthlyMean(reefID: number) {
@@ -11,16 +11,18 @@ function getMaximumMonthlyMean(reefID: number) {
 
 test('Not enough SST.', () => {
   const seaSurfaceTemperatures = getSeaSurfaceTemperatures(1);
-  const maximumMonthlyMean = getMaximumMonthlyMean(1)
-  return expect(
-    () => { calculateDegreeHeatingDays(seaSurfaceTemperatures, maximumMonthlyMean) }).toThrow(
-      Error
-    );
+  const maximumMonthlyMean = getMaximumMonthlyMean(1);
+  return expect(() => {
+    calculateDegreeHeatingDays(seaSurfaceTemperatures, maximumMonthlyMean);
+  }).toThrow(Error);
 });
 
 test('Calculates data as expected.', () => {
   const seaSurfaceTemperatures = getSeaSurfaceTemperatures(84);
-  const maximumMonthlyMean = getMaximumMonthlyMean(1)
-  const DHD = calculateDegreeHeatingDays(seaSurfaceTemperatures, maximumMonthlyMean)
-  expect(DHD).toBe(1512)
+  const maximumMonthlyMean = getMaximumMonthlyMean(1);
+  const DHD = calculateDegreeHeatingDays(
+    seaSurfaceTemperatures,
+    maximumMonthlyMean,
+  );
+  expect(DHD).toBe(1512);
 });

--- a/packages/api/src/utils/temperature.ts
+++ b/packages/api/src/utils/temperature.ts
@@ -1,4 +1,4 @@
-/** 
+/**
  * Corals start to become stressed when the SST is 1°C warmer than the maxiumum monthly mean temperature (MMM).
  * The MMM is the highest temperature out of the monthly mean temperatures over the year (warmest summer month)
  * 1°C above the MMM is called the "bleaching threshhold"
@@ -7,14 +7,14 @@
  * The DHW shows how much heat stress has accumulated in an area over the past 12 weeks (3 months). The units for DHW are "degree C-weeks"
  * The DHW adds up the Coral Bleaching HotSpot values whenever the temperature exceeds the bleaching threshold.
  * Bleaching Alerts:
- *      No Stress (no heat stress or bleaching is present): HotSpot of less than or equal to 0. 
- *      Bleaching Watch (low-level heat stress is present): HotSpot greater than 0 but less than 1; SST below bleaching threshhold. 
- *      Bleaching Warning (heat stress is accumulating, possible coral bleaching): HotSpot of 1 or greater; SST above bleaching threshold; DHW greater than 0 but less than 4. 
- *      Bleaching Alert Level 1 (significant bleaching likely): HotSpot of 1 or greater; SST above bleaching threshold; DHW greater than or equal to 4 but less than 8. 
- *      Bleaching Alert Level 2 (severe bleaching and significant mortality likely): HotSpot of 1 or greater; SST above bleaching threshold; DHW greater than or equal to 8. 
- * 
+ *      No Stress (no heat stress or bleaching is present): HotSpot of less than or equal to 0.
+ *      Bleaching Watch (low-level heat stress is present): HotSpot greater than 0 but less than 1; SST below bleaching threshhold.
+ *      Bleaching Warning (heat stress is accumulating, possible coral bleaching): HotSpot of 1 or greater; SST above bleaching threshold; DHW greater than 0 but less than 4.
+ *      Bleaching Alert Level 1 (significant bleaching likely): HotSpot of 1 or greater; SST above bleaching threshold; DHW greater than or equal to 4 but less than 8.
+ *      Bleaching Alert Level 2 (severe bleaching and significant mortality likely): HotSpot of 1 or greater; SST above bleaching threshold; DHW greater than or equal to 8.
+ *
  * DHW = (1/7)*sum[1->84](HS(i) if HS(i) >= 1C)
-**/
+ * */
 
 /**
  * Calculates the Degree Heating Days of a reef location using 12 weeks of data.
@@ -29,15 +29,20 @@
  * @return {float}     degreeHeatingDays             Degree Heating Days
  */
 
-export function calculateDegreeHeatingDays(seaSurfaceTemperatures: number[], maximumMonthlyMean: number) {
+export function calculateDegreeHeatingDays(
+  seaSurfaceTemperatures: number[],
+  maximumMonthlyMean: number,
+) {
   if (seaSurfaceTemperatures.length !== 84) {
-    throw new Error('Calculating Degree Heating Days requires exactly 84 days of data.');
+    throw new Error(
+      'Calculating Degree Heating Days requires exactly 84 days of data.',
+    );
   }
 
   return seaSurfaceTemperatures.reduce((sum, value) => {
     // Calculate deviation.
-    const degreeDeviation = value - maximumMonthlyMean
+    const degreeDeviation = value - maximumMonthlyMean;
     // Add degree deviation for days above bleaching threshold (MMM + 1 degree).
     return sum + (degreeDeviation >= 1 ? value - maximumMonthlyMean : 0);
-  }, 0)
-};
+  }, 0);
+}

--- a/packages/api/test/app.e2e-spec.ts
+++ b/packages/api/test/app.e2e-spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { AppModule } from './../src/app.module';
+import { AppModule } from '../src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;


### PR DESCRIPTION
Slight update to the linting configuration. This makes `yarn lint:all` in the project root directory use lerna to run `yarn lint` in each sub repo rather than a single invocation with a "blob" operator from the root. Hopefully this will fix the ci linting errors.